### PR TITLE
Cookieに有効期限を設定

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ const http = require('http');
 const server = http.createServer((req, res) => {
   const now = new Date().getTime();
   res.setHeader('Set-Cookie', 'last_access=' + now + '; expires=Mon, 07 Jan 2036 00:00:00 GMT;');
-  res.end(req.headers.cookie);
+  const last_access_time = req.headers.cookie ? parseInt(req.headers.cookie.split('last_access=')[1]) : now;
+  res.end(new Date(last_access_time).toString());
 });
 const port = 8000;
 server.listen(port, () => {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const http = require('http');
 const server = http.createServer((req, res) => {
   const now = new Date().getTime();
-  res.setHeader('Set-Cookie', 'last_access=' + now + ';');
+  res.setHeader('Set-Cookie', 'last_access=' + now + '; expires=Mon, 07 Jan 2036 00:00:00 GMT;');
   res.end(req.headers.cookie);
 });
 const port = 8000;


### PR DESCRIPTION
練習用プルリクエストですので、マージ不要です。

「練習の答え」ではミリ秒で表示することになっていたので、
テキストを見て時刻で表示するようにしました。