### PR TITLE
Cookie の有効期限を設定するように実装

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,14 @@
 'use strict';
 const http = require('http');
 const server = http.createServer((req, res) => {
-  const now = new Date().getTime();
-  res.setHeader('Set-Cookie', 'last_access=' + now + ';');
-  res.end(req.headers.cookie);
+  res.setHeader('Set-Cookie', 'rensyu=2525; expires=Wed, 05 Feb 2025 00:25:25 GMT;');
+  // cookie の寿命（expires）をブラウザか、コンソールに表示させることが【自分自身の今回の課題】なので、少し簡略化。
+  res.end( '<pre>'+ req.headers.cookie+ '</pre>');
+  // 結局、クッキーの寿命をブラウザに出力させる事が出え着なかった。
+  // 頑張ったアピールするために、無効と知りつつ、 preタグを追加した。
+  // 前処理として、 ';' とかで splitとかしてしまうと、エラーが起きた。
+  // 型宣言か、型の理解が足りていないようだ。
+  // cookie の値に、半角スペースや制御文字( ;とか "とか)を含んではいけないところまでは調べたのだが・・・。残念、タイムアップ。
 });
 const port = 8000;
 server.listen(port, () => {


### PR DESCRIPTION
練習問題なので、マージは不要です。

クッキーの有効期限を、ブラウザにも表示するようにしたかったのですが、出来ませんでした。（ Chrome のデベロッパーツールでは、無事に動作確認できています。）

現状だと、 name と value だけがブラウザ上に表示されます。
有効期限の expires を表示させたかったのですが、型の理解不足か、改行制御文字を気にした正規表現の理解不足かもしれません。
「クッキー自体に、制御文字が入らないように気をつけましょう。」というところまでは、調べる事が出来たのですが、もう一歩、力が及びませんでした。