### PR TITLE
Cookieに有効期限を設定

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const http = require('http');
 const server = http.createServer((req, res) => {
   const now = new Date().getTime();
-  res.setHeader('Set-Cookie', 'last_access=' + now + ';');
+  res.setHeader('Set-Cookie', 'last_access=' + now + ';' + 'expires=Mon, 07 Jan 2036 00:00:00 GMT;');
   res.end(req.headers.cookie);
 });
 const port = 8000;


### PR DESCRIPTION
入力途中でエディタが時刻部分を「00: 00: 00」と整形したため、有効期限が正確に設定されないつまづきがあった