### PR TITLE
Cookieの有効期限を追加

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const http = require('http');
 const server = http.createServer((req, res) => {
   const now = Date.now();
-  res.setHeader('Set-Cookie', 'last_access=' + now + ';');
+  res.setHeader('Set-Cookie', 'last_access=' + now + '; expires=Mon, 07 Jan 2036 00:00:00 GMT;');
   res.end(req.headers.cookie);
 });
 const port = 8000;


### PR DESCRIPTION
Cookieの有効期限を2036年1月7日に設定.
練習のためマージ不要